### PR TITLE
🤢 Return isStale if value was not updated for a long time

### DIFF
--- a/src/Oracle.sol
+++ b/src/Oracle.sol
@@ -32,7 +32,7 @@ contract Oracle {
     /// @return the current value of the oracle
     /// @return whether the value is stale (true) or fresh (false)
     function value() public view returns (int256, bool) {
-        bool isStale = block.timestamp >= lastTimestamp + minTimeBetweenUpdates;
+        bool isStale = block.timestamp >= lastTimestamp + minTimeBetweenUpdates * 2;
         return (ema, isStale);
     }
 

--- a/src/Oracle.t.sol
+++ b/src/Oracle.t.sol
@@ -36,7 +36,7 @@ contract OracleTest is DSTest {
             })
         );
 
-        hevm.warp(minTimeBetweenWindows + 1);
+        hevm.warp(minTimeBetweenWindows * 10);
     }
 
     function test_deploy() public {
@@ -174,7 +174,7 @@ contract OracleTest is DSTest {
         oracle.update();
 
         // Advance time
-        hevm.warp(block.timestamp + minTimeBetweenWindows + 1);
+        hevm.warp(block.timestamp + minTimeBetweenWindows * 2 + 1);
 
         // Check stale value
         (, bool isStale) = oracle.value();


### PR DESCRIPTION
If the returned `value()` was not updated recently, the returned value is marked as stale.

The method `value()` returns 2 values:
- value - the exponential moving average
- isStale - true if the value was not updated in `minTimeBetweenUpdates * 2`