### PR TITLE
Renamed YieldSpace to Yield

### DIFF
--- a/src/valueprovider/Yield/IYieldPool.sol
+++ b/src/valueprovider/Yield/IYieldPool.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
-/// @notice The Yield Space pool contract interface
+/// @notice The Yield pool contract interface
 /// Only the useful functionality is defined in the interface.
 /// For the full contract interface:
 /// https://github.com/yieldprotocol/yieldspace-interfaces/blob/0266fbfd0117ff821cb2f43010a004cc44d1bfc1/IPool.sol
 /// deployed contract example : https://etherscan.io/address/0x3771c99c087a81df4633b50d8b149afaa83e3c9e
-interface IYieldSpacePool {
+interface IYieldPool {
     function ts() external view returns (int128);
 
     function getCache()

--- a/src/valueprovider/Yield/YieldValueProvider.sol
+++ b/src/valueprovider/Yield/YieldValueProvider.sol
@@ -2,26 +2,26 @@
 pragma solidity ^0.8.0;
 
 import {IValueProvider} from "../IValueProvider.sol";
-import {IYieldSpacePool} from "./IYieldSpacePool.sol";
+import {IYieldPool} from "./IYieldPool.sol";
 import "lib/prb-math/contracts/PRBMathSD59x18.sol";
 import "lib/abdk-libraries-solidity/ABDKMath64x64.sol";
 
-contract YieldSpaceValueProvider is IValueProvider {
-    IYieldSpacePool public immutable yieldPool;
+contract YieldValueProvider is IValueProvider {
+    IYieldPool public immutable yieldPool;
 
     constructor(address yieldPool_) {
-        yieldPool = IYieldSpacePool(yieldPool_);
+        yieldPool = IYieldPool(yieldPool_);
     }
 
     /// @notice Calculates the annual rate used by the FiatDao contracts
-    /// based on the token reservers, underlier reserves and time scale from the yield space contract
+    /// based on the token reservers, underlier reserves and time scale from the yield contract
     /// @dev formula documentation:
     /// https://www.notion.so/fiatdao/FIAT-Interest-Rate-Oracle-System-01092c10abf14e5fb0f1353b3b24a804
     /// @return result The result as an signed 59.18-decimal fixed-point number.
     function value() external view override(IValueProvider) returns (int256) {
         uint112 fyTokenReserves;
         uint112 underlierReserves;
-        // The TS returned by the Yield Space contract is in 64.64 format and we need to convert it to int256
+        // The TS returned by the Yield contract is in 64.64 format and we need to convert it to int256
         // we do that by computing the inverse of the scale which will give us the time window in seconds
         int256 inverseTS = int256(
             ABDKMath64x64.toInt(ABDKMath64x64.inv(yieldPool.ts()))

--- a/src/valueprovider/Yield/YieldValueProvider.t.sol
+++ b/src/valueprovider/Yield/YieldValueProvider.t.sol
@@ -6,25 +6,25 @@ import "ds-test/test.sol";
 import "src/test/utils/Caller.sol";
 import {Hevm} from "src/test/utils/Hevm.sol";
 import {MockProvider} from "src/test/utils/MockProvider.sol";
-import {YieldSpaceValueProvider} from "./YieldSpaceValueProvider.sol";
-import {IYieldSpacePool} from "./IYieldSpacePool.sol";
+import {YieldValueProvider} from "./YieldValueProvider.sol";
+import {IYieldPool} from "./IYieldPool.sol";
 
-contract YieldSpaceTest is DSTest {
+contract YieldValueProviderTest is DSTest {
     Hevm internal hevm = Hevm(DSTest.HEVM_ADDRESS);
 
     MockProvider internal mockValueProvider;
 
-    YieldSpaceValueProvider internal yieldSpaceVP;
+    YieldValueProvider internal yieldVP;
 
     function setUp() public {
         mockValueProvider = new MockProvider();
-        yieldSpaceVP = new YieldSpaceValueProvider(address(mockValueProvider));
+        yieldVP = new YieldValueProvider(address(mockValueProvider));
 
         // Set the value returned by the pool contract
-        // values taken from a YieldSpace Pool contract deployed at:
+        // values taken from a Yield Pool contract deployed at:
         // 0x3771c99c087a81df4633b50d8b149afaa83e3c9e at block 13911954
         mockValueProvider.givenQueryReturnResponse(
-            abi.encodePacked(IYieldSpacePool.ts.selector),
+            abi.encodePacked(IYieldPool.ts.selector),
             MockProvider.ReturnData({
                 success: true,
                 data: abi.encode(int128(58454204609))
@@ -33,7 +33,7 @@ contract YieldSpaceTest is DSTest {
         );
 
         mockValueProvider.givenQueryReturnResponse(
-            abi.encodePacked(IYieldSpacePool.getCache.selector),
+            abi.encodePacked(IYieldPool.getCache.selector),
             MockProvider.ReturnData({
                 success: true,
                 data: abi.encode(
@@ -47,13 +47,13 @@ contract YieldSpaceTest is DSTest {
     }
 
     function test_deploy() public {
-        assertTrue(address(yieldSpaceVP) != address(0));
+        assertTrue(address(yieldVP) != address(0));
     }
 
     function test_GetValue() public {
         // Computed value based on the parameters that are sent via the mock provider
         int256 computedValue = 65412864833148000;
-        int256 value = yieldSpaceVP.value();
+        int256 value = yieldVP.value();
 
         assertTrue(value == computedValue);
     }


### PR DESCRIPTION
As requested by @elnilz, YieldSpace was renamed to Yield.

Fixes #32 