### PR TITLE
🛼 Exit early if the Oracle was not updated (do not update Collybus)

### DIFF
--- a/src/relayer/Relayer.sol
+++ b/src/relayer/Relayer.sol
@@ -209,7 +209,11 @@ contract Relayer is Guarded, IRelayer {
             }
             (int256 oracleValue, bool isValid) = IOracle(localOracle).value();
 
+            // If the value is invalid we don't need to update Collybus
             if (!isValid) continue;
+
+            // If the oracle was not updated we don't need to update Collybus
+            if (!oracleUpdated) continue;
 
             OracleData storage oracleData = _oraclesData[localOracle];
 


### PR DESCRIPTION
### Description

If the oracle was not updated there should be no Collybus update. Thus, this PR makes Collybus exit early if the oracle was not updated.

### Issues

No issue was created since this was reported directly by the auditor team.

### Todo

- [ ] Link issues
- [ ] Link projects
- [ ] Update tests
- [x] Update code
- [x] Comment code
- [x] Test locally
- [ ] Update changelog