### PR TITLE
🏸 Only emit `OracleUpdated` event if the oracle was actually updated

### DIFF
--- a/src/aggregator/AggregatorOracle.sol
+++ b/src/aggregator/AggregatorOracle.sol
@@ -159,10 +159,9 @@ contract AggregatorOracle is Guarded, Pausable, IAggregatorOracle, IOracle {
             IOracle oracle = IOracle(_oracles.at(i));
 
             try oracle.update() returns (bool localUpdated) {
-                emit OracleUpdated(address(oracle));
-
                 // If at least one oracle updated successfully, set the flag
                 if (localUpdated) {
+                    emit OracleUpdated(address(oracle));
                     updated = true;
                 }
 


### PR DESCRIPTION
### Description

Only emit the `OracleUpdated` if the oracle was actually updated

### Issues

No issue was created since this was reported directly by the auditor team.

### Todo

- [ ] Link issues
- [ ] Link projects
- [ ] Update tests
- [x] Update code
- [ ] Comment code
- [x] Test locally
- [ ] Update changelog