### PR TITLE
Fix/static relayer remove guarded

### DIFF
--- a/src/factory/RelayerFactory.sol
+++ b/src/factory/RelayerFactory.sol
@@ -77,10 +77,6 @@ contract RelayerFactory is IRelayerFactory {
             value_
         );
 
-        // Pass permissions to the intended contract owner
-        staticRelayer.allowCaller(staticRelayer.ANY_SIG(), msg.sender);
-        staticRelayer.blockCaller(staticRelayer.ANY_SIG(), address(this));
-
         emit StaticRelayerDeployed(
             address(staticRelayer),
             relayerType_,

--- a/src/factory/RelayerFactory.t.sol
+++ b/src/factory/RelayerFactory.t.sol
@@ -162,33 +162,4 @@ contract RelayerFactoryTest is DSTest {
             "Caller should have rights over the created contract"
         );
     }
-
-    function test_createStatic_factoryPassesPermissions() public {
-        StaticRelayer staticRelayer = StaticRelayer(
-            _factory.createStatic(
-                _collybusAddress,
-                _relayerType,
-                _encodedTokenId,
-                1
-            )
-        );
-
-        bool factoryIsAuthorized = staticRelayer.canCall(
-            staticRelayer.ANY_SIG(),
-            address(_factory)
-        );
-        assertTrue(
-            factoryIsAuthorized == false,
-            "The Factory should not have rights over the created contract"
-        );
-
-        bool callerIsAuthorized = staticRelayer.canCall(
-            staticRelayer.ANY_SIG(),
-            address(this)
-        );
-        assertTrue(
-            callerIsAuthorized,
-            "Caller should have rights over the created contract"
-        );
-    }
 }

--- a/src/relayer/StaticRelayer.sol
+++ b/src/relayer/StaticRelayer.sol
@@ -6,7 +6,9 @@ import {IRelayer} from "./IRelayer.sol";
 
 contract StaticRelayer is IRelayer {
     /// @notice Emitted during executeWithRevert() if the Collybus was already updated
-    error StaticRelayer__executeWithRevert_collybusAlreadyUpdated(IRelayer.RelayerType relayerType);
+    error StaticRelayer__executeWithRevert_collybusAlreadyUpdated(
+        IRelayer.RelayerType relayerType
+    );
 
     /// ======== Events ======== ///
 
@@ -42,8 +44,7 @@ contract StaticRelayer is IRelayer {
     /// @notice Pushes the hardcoded value to Collybus for the hardcoded token id
     /// After the rate is pushed the contract self-destructs
     function execute() public override(IRelayer) returns (bool) {
-        if(_updatedCollybus)
-            return false;
+        if (_updatedCollybus) return false;
 
         _updatedCollybus = true;
         if (relayerType == IRelayer.RelayerType.DiscountRate) {
@@ -65,7 +66,9 @@ contract StaticRelayer is IRelayer {
     /// @notice The function will call `execute()` and will revert if _updatedCollybus is true
     function executeWithRevert() public override(IRelayer) {
         if (!execute()) {
-            revert StaticRelayer__executeWithRevert_collybusAlreadyUpdated(relayerType);
+            revert StaticRelayer__executeWithRevert_collybusAlreadyUpdated(
+                relayerType
+            );
         }
     }
 }

--- a/src/relayer/StaticRelayer.sol
+++ b/src/relayer/StaticRelayer.sol
@@ -3,9 +3,11 @@ pragma solidity ^0.8.0;
 
 import {ICollybus} from "./ICollybus.sol";
 import {IRelayer} from "./IRelayer.sol";
-import {Guarded} from "../guarded/Guarded.sol";
 
-contract StaticRelayer is Guarded {
+contract StaticRelayer is IRelayer {
+    /// @notice Emitted during executeWithRevert() if the Collybus was already updated
+    error StaticRelayer__executeWithRevert_collybusAlreadyUpdated(IRelayer.RelayerType relayerType);
+
     /// ======== Events ======== ///
 
     event UpdatedCollybus(
@@ -21,6 +23,9 @@ contract StaticRelayer is Guarded {
     bytes32 public immutable encodedTokenId;
     uint256 public immutable value;
 
+    // Flag used to ensure that the value is pushed to Collybus only once
+    bool private _updatedCollybus;
+
     constructor(
         address collybusAddress_,
         IRelayer.RelayerType type_,
@@ -31,11 +36,16 @@ contract StaticRelayer is Guarded {
         relayerType = type_;
         encodedTokenId = encodedTokenId_;
         value = value_;
+        _updatedCollybus = false;
     }
 
     /// @notice Pushes the hardcoded value to Collybus for the hardcoded token id
     /// After the rate is pushed the contract self-destructs
-    function execute() public {
+    function execute() public override(IRelayer) returns (bool) {
+        if(_updatedCollybus)
+            return false;
+
+        _updatedCollybus = true;
         if (relayerType == IRelayer.RelayerType.DiscountRate) {
             ICollybus(collybus).updateDiscountRate(
                 uint256(encodedTokenId),
@@ -49,7 +59,13 @@ contract StaticRelayer is Guarded {
         }
 
         emit UpdatedCollybus(encodedTokenId, value, relayerType);
+        return true;
+    }
 
-        selfdestruct(payable(address(0)));
+    /// @notice The function will call `execute()` and will revert if _updatedCollybus is true
+    function executeWithRevert() public override(IRelayer) {
+        if (!execute()) {
+            revert StaticRelayer__executeWithRevert_collybusAlreadyUpdated(relayerType);
+        }
     }
 }

--- a/src/relayer/StaticRelayer.t.sol
+++ b/src/relayer/StaticRelayer.t.sol
@@ -89,4 +89,35 @@ contract StaticRelayerTest is DSTest {
             "Invalid spot price in Collybus"
         );
     }
+
+    function test_executeWithRevert() public {
+        address tokenAddress = address(0x1234);
+        // The Collybus type does not change the behavior so we can use either of them
+        StaticRelayer staticRelayer = new StaticRelayer(
+            address(collybus),
+            IRelayer.RelayerType.SpotPrice,
+            bytes32(uint256(uint160(tokenAddress))),
+            1e18
+        );
+
+        // Call should not revert
+        staticRelayer.executeWithRevert();
+    }
+
+    function testFail_executeWithRevert_shouldRevertAfterCollybusIsUpdated() public {
+        address tokenAddress = address(0x1234);
+        // The Collybus type does not change the behavior so we can use either of them
+        StaticRelayer staticRelayer = new StaticRelayer(
+            address(collybus),
+            IRelayer.RelayerType.SpotPrice,
+            bytes32(uint256(uint160(tokenAddress))),
+            1e18
+        );
+
+        // Call execute so the StaticRelayer will update the Collybus
+        staticRelayer.execute();
+
+        // Attempt cu call it again, call should revert
+        staticRelayer.executeWithRevert();
+    }
 }

--- a/src/relayer/StaticRelayer.t.sol
+++ b/src/relayer/StaticRelayer.t.sol
@@ -104,7 +104,9 @@ contract StaticRelayerTest is DSTest {
         staticRelayer.executeWithRevert();
     }
 
-    function testFail_executeWithRevert_shouldRevertAfterCollybusIsUpdated() public {
+    function testFail_executeWithRevert_shouldRevertAfterCollybusIsUpdated()
+        public
+    {
         address tokenAddress = address(0x1234);
         // The Collybus type does not change the behavior so we can use either of them
         StaticRelayer staticRelayer = new StaticRelayer(

--- a/src/relayer/StaticRelayer.t.sol
+++ b/src/relayer/StaticRelayer.t.sol
@@ -116,10 +116,10 @@ contract StaticRelayerTest is DSTest {
             1e18
         );
 
-        // Call execute so the StaticRelayer will update the Collybus
+        // Call execute() so the StaticRelayer will update the Collybus
         staticRelayer.execute();
 
-        // Attempt cu call it again, call should revert
+        // Call to executeWithRevert() should revert because we already updated the Collybus
         staticRelayer.executeWithRevert();
     }
 }


### PR DESCRIPTION
### Description

Updated the ``StaticRelayer`` to implement the ``IRelayer`` interface and removed the ``Guarded`` dependency as it was not used.

### Issues

- Closes #109 

### Todo

- [ ] Link issues
- [ ] Link projects
- [ ] Update tests
- [ ] Update code
- [ ] Comment code
- [ ] Test locally
- [ ] Update changelog