### PR TITLE
Fixed how the LUSD3CRV ValueProvider handles decimals

### DIFF
--- a/src/factory/LUSD3CRVFactory.sol
+++ b/src/factory/LUSD3CRVFactory.sol
@@ -14,7 +14,7 @@ contract LUSD3CRVFactory {
     /// push data to Collybus
     /// @param timeUpdateWindow_ Minimum time between updates of the value
     /// @param curve3Pool_ Address of the  Curve 3pool
-    /// @param curveLUSD3Pool_ Address of the Curve LUSD-3pool pool
+    /// @param curve3PoolLpToken_ Address of the lp token for the Curve 3pool
     /// @param chainlinkLUSD_ Address of the LUSD chainlink data feed
     /// @param chainlinkUSDC_ Address of the USDC chainlink data feed
     /// @param chainlinkDAI_ Address of the DAI chainlink data feed
@@ -28,16 +28,18 @@ contract LUSD3CRVFactory {
         uint256 timeUpdateWindow_,
         // LUSD3CRVValueProvider specific parameters
         address curve3Pool_,
-        address curveLUSD3Pool_,
+        address curve3PoolLpToken_,
         address chainlinkLUSD_,
         address chainlinkUSDC_,
         address chainlinkDAI_,
         address chainlinkUSDT_
     ) public returns (address) {
+        // The tokenAddress is the address of the LUSD3CRV Curve Pool so we can pass it to the Oracle
         LUSD3CRVValueProvider lusd3crvValueProvider = new LUSD3CRVValueProvider(
             timeUpdateWindow_,
             curve3Pool_,
-            curveLUSD3Pool_,
+            curve3PoolLpToken_,
+            tokenAddress_,
             chainlinkLUSD_,
             chainlinkUSDC_,
             chainlinkDAI_,

--- a/src/factory/LUSD3CRVFactory.t.sol
+++ b/src/factory/LUSD3CRVFactory.t.sol
@@ -17,7 +17,6 @@ import {IChainlinkAggregatorV3Interface} from "../oracle_implementations/spot_pr
 contract LUSD3CRVFactoryTest is DSTest {
     address private _collybusAddress = address(0xC011b005);
     uint256 private _oracleUpdateWindow = 1 * 3600;
-    address private _tokenAddress = address(0x105311);
     uint256 private _minimumPercentageDeltaValue = 25;
 
     address private _lusd3crvRelayerAddress;
@@ -37,21 +36,23 @@ contract LUSD3CRVFactoryTest is DSTest {
             false
         );
 
-        MockProvider curvePoolMock = new MockProvider();
-        curvePoolMock.givenQueryReturnResponse(
-            abi.encodeWithSelector(ICurvePool.decimals.selector),
+        MockProvider curveTokenMock = new MockProvider();
+        curveTokenMock.givenQueryReturnResponse(
+            abi.encodeWithSelector(ERC20.decimals.selector),
             MockProvider.ReturnData({success: true, data: abi.encode(18)}),
             false
         );
 
+        // We can use a random curve 3pool address
+        address curve3PoolAddress = address(0xC1133);
         // Create the Relayer
         _lusd3crvRelayerAddress = _factory.create(
             _collybusAddress,
-            _tokenAddress,
+            address(curveTokenMock),
             _minimumPercentageDeltaValue,
             _oracleUpdateWindow,
-            address(curvePoolMock),
-            address(curvePoolMock),
+            curve3PoolAddress,
+            address(curveTokenMock),
             address(chainlinkMock),
             address(chainlinkMock),
             address(chainlinkMock),
@@ -90,9 +91,8 @@ contract LUSD3CRVFactoryTest is DSTest {
             "LUSD3CRV Relayer incorrect RelayerType"
         );
 
-        assertEq(
-            Relayer(_lusd3crvRelayerAddress).encodedTokenId(),
-            bytes32(uint256(uint160(_tokenAddress))),
+        assertTrue(
+            Relayer(_lusd3crvRelayerAddress).encodedTokenId() != bytes32(0),
             "LUSD3CRV Relayer incorrect tokenId"
         );
 

--- a/src/oracle_implementations/spot_price/Chainlink/LUSD3CRV/ICurvePool.sol
+++ b/src/oracle_implementations/spot_price/Chainlink/LUSD3CRV/ICurvePool.sol
@@ -4,6 +4,4 @@ pragma solidity ^0.8.0;
 /// @notice Lightweight interface used to interrogate Curve pools
 interface ICurvePool {
     function get_virtual_price() external view returns (uint256);
-
-    function decimals() external view returns (uint256);
 }

--- a/src/oracle_implementations/spot_price/Chainlink/LUSD3CRV/LUSD3CRVValueProvider.sol
+++ b/src/oracle_implementations/spot_price/Chainlink/LUSD3CRV/LUSD3CRVValueProvider.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import {Oracle} from "../../../../oracle/Oracle.sol";
 import {Convert} from "../../../discount_rate/utils/Convert.sol";
 import {IChainlinkAggregatorV3Interface} from "../ChainlinkAggregatorV3Interface.sol";
@@ -39,21 +40,22 @@ contract LUSD3CRVValueProvider is Oracle, Convert {
         uint256 timeUpdateWindow_,
         // Chainlink specific parameters
         address curve3Pool_,
+        address curve3PoolLpToken_,
         address curveLUSD3Pool_,
         address chainlinkLUSD_,
         address chainlinkUSDC_,
         address chainlinkDAI_,
         address chainlinkUSDT_
     ) Oracle(timeUpdateWindow_) {
-        if (ICurvePool(curve3Pool_).decimals() != 18) {
+        // Init the Curve 3pool
+        if (ERC20(curve3PoolLpToken_).decimals() != 18) {
             revert LUSD3CRVValueProvider__constructor_InvalidPoolDecimals(
                 curve3Pool_
             );
         }
-        // Init the Curve 3pool
         curve3Pool = curve3Pool_;
 
-        if (ICurvePool(curveLUSD3Pool_).decimals() != 18) {
+        if (ERC20(curveLUSD3Pool_).decimals() != 18) {
             revert LUSD3CRVValueProvider__constructor_InvalidPoolDecimals(
                 curveLUSD3Pool_
             );

--- a/src/oracle_implementations/spot_price/Chainlink/LUSD3CRV/LUSD3CRVValueProvider.sol
+++ b/src/oracle_implementations/spot_price/Chainlink/LUSD3CRV/LUSD3CRVValueProvider.sol
@@ -30,6 +30,7 @@ contract LUSD3CRVValueProvider is Oracle, Convert {
     /// @notice Constructs the Value provider contracts with the needed Chainlink data feeds
     /// @param timeUpdateWindow_ Minimum time between updates of the value
     /// @param curve3Pool_ Address of the  Curve 3pool
+    /// @param curve3PoolLpToken_ Address of the lp token for the Curve 3pool
     /// @param curveLUSD3Pool_ Address of the Curve LUSD-3pool pool
     /// @param chainlinkLUSD_ Address of the LUSD chainlink data feed
     /// @param chainlinkUSDC_ Address of the USDC chainlink data feed

--- a/src/oracle_implementations/spot_price/Chainlink/LUSD3CRV/LUSD3CRVValueProvider.sol
+++ b/src/oracle_implementations/spot_price/Chainlink/LUSD3CRV/LUSD3CRVValueProvider.sol
@@ -48,12 +48,12 @@ contract LUSD3CRVValueProvider is Oracle, Convert {
         address chainlinkDAI_,
         address chainlinkUSDT_
     ) Oracle(timeUpdateWindow_) {
-        // Init the Curve 3pool
         if (ERC20(curve3PoolLpToken_).decimals() != 18) {
             revert LUSD3CRVValueProvider__constructor_InvalidPoolDecimals(
                 curve3Pool_
             );
         }
+        // Init the Curve 3pool
         curve3Pool = curve3Pool_;
 
         if (ERC20(curveLUSD3Pool_).decimals() != 18) {


### PR DESCRIPTION
### Description

The current implementation interrogates the Curve3Pool contract for the lp token decimals which triggers a **Revert**. 
The issues was fixed by passing the lp token address to the Oracle in order to perform the check.

### Issues

None

### Todo

- [ ] Link issues
- [x] Link projects
- [x] Update tests
- [x] Update code
- [x] Comment code
- [x] Test locally
- [ ] Update changelog