### PR TITLE
Relayer.executeWithRevert() reverts if Collybus is not updated

### DIFF
--- a/src/relayer/Relayer.sol
+++ b/src/relayer/Relayer.sol
@@ -71,6 +71,7 @@ contract Relayer is Guarded, IRelayer {
 
     /// @notice Updates the oracle and pushes the updated data to Collybus if the
     /// delta change in value is bigger than the minimum threshold value.
+    /// @return Whether the Collybus was updated or not
     function execute() public override(IRelayer) returns (bool) {
         // We always update the oracles before retrieving the rates
         bool oracleUpdated = IOracle(oracle).update();
@@ -86,7 +87,8 @@ contract Relayer is Guarded, IRelayer {
                 minimumPercentageDeltaValue
             )
         ) {
-            return oracleUpdated;
+            // Collybus was not updated so we return false
+            return false;
         }
 
         _lastUpdateValue = oracleValue;
@@ -105,7 +107,8 @@ contract Relayer is Guarded, IRelayer {
 
         emit UpdatedCollybus(encodedTokenId, uint256(oracleValue), relayerType);
 
-        return oracleUpdated;
+        // Collybus was updated
+        return true;
     }
 
     /// @notice The function will call `execute()` and will revert if the oracle was not updated

--- a/src/relayer/Relayer.t.sol
+++ b/src/relayer/Relayer.t.sol
@@ -281,7 +281,7 @@ contract RelayerTest is DSTest {
         relayer.executeWithRevert();
     }
 
-    function test_execute_returnsTrue_whenTheOracleIsUpdated() public {
+    function test_execute_returnsTrue_whenCollybusIsUpdated() public {
         bool executed;
 
         executed = relayer.execute();
@@ -289,37 +289,33 @@ contract RelayerTest is DSTest {
         assertTrue(executed, "The relayer should return true");
     }
 
-    function test_execute_returnsFalse_whenTheOracleIsNotUpdated() public {
+    function test_execute_returnsFalse_whenCollybusIsNotUpdated() public {
         bool executed;
-
-        oracle.givenQueryReturnResponse(
-            abi.encodePacked(IOracle.update.selector),
-            MockProvider.ReturnData({success: true, data: abi.encode(false)}),
-            false
-        );
 
         executed = relayer.execute();
 
+        // The first execute should return true
+        assertTrue(executed, "The relayer should return true");
+
+        executed = relayer.execute();
+
+        // The second execute should return false because the Collybus will not be updated
         assertTrue(executed == false, "The relayer should return false");
     }
 
-    function test_executeWithRevert_shouldBeSuccessful_whenTheOracleIsUpdated()
+    function test_executeWithRevert_shouldBeSuccessful_whenCollybusIsUpdated()
         public
     {
         // Call should not revert
         relayer.executeWithRevert();
     }
 
-    function testFail_executeWithRevert_shouldNotBeSuccessful_whenTheOracleIsNotUpdated()
+    function testFail_executeWithRevert_shouldNotBeSuccessful_whenCollybusIsNotUpdated()
         public
     {
-        oracle.givenQueryReturnResponse(
-            abi.encodePacked(IOracle.update.selector),
-            MockProvider.ReturnData({success: true, data: abi.encode(false)}),
-            false
-        );
+        relayer.execute();
 
-        // Call should not revert
+        // Call should revert
         relayer.executeWithRevert();
     }
 }


### PR DESCRIPTION
### Description

Updated `Relayer.execute()` to return whether the `Collybus` was updated or not instead of if the `Oracle` was updated.
This will make `Relayer.executeWithRevert()` to revert if the `Collybus` was not updated.

### Issues

- Closes #123 

### Todo

- [x] Link issues
- [x] Link projects
- [x] Update tests
- [x] Update code
- [x] Comment code
- [x] Test locally
- [ ] Update changelog