### PR TITLE
Updated the Relayer.execute() logic to properly support keeper updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,5 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Redesigned some events in `AggregatorOracle` to also emit the oracle's address. Issue [#79](https://github.com/fiatdao/delphi/issues/79)
 - Upgrade Solidity version from 0.8.7 to 0.8.12. Issue [#73](https://github.com/fiatdao/delphi/issues/73)
 - Changed execution flow for `executeWithRevert` to allow for oracle updates even if no update to Collybus was performed. Issue [#83](https://github.com/fiatdao/delphi/issues/83)
+- Updated `Relayer.execute()` to return whether a keeper should execute or not the current transaction instead of if Collybus was updated. Fix for issue [#125](https://github.com/fiatdao/delphi/issues/125)
 
 ### Removed

--- a/src/oracle/IOracle.sol
+++ b/src/oracle/IOracle.sol
@@ -4,5 +4,7 @@ pragma solidity ^0.8.0;
 interface IOracle {
     function value() external view returns (int256, bool);
 
+    function nextValue() external view returns (int256);
+
     function update() external returns (bool);
 }

--- a/src/oracle/Oracle.sol
+++ b/src/oracle/Oracle.sol
@@ -23,7 +23,7 @@ abstract contract Oracle is Pausable, IOracle {
     uint256 public lastTimestamp;
 
     // The next value that will replace the current value once the timeUpdateWindow has passed
-    int256 public nextValue;
+    int256 public override(IOracle) nextValue;
 
     // Current value that will be returned by the Oracle
     int256 private _currentValue;

--- a/src/relayer/Relayer.t.sol
+++ b/src/relayer/Relayer.t.sol
@@ -57,6 +57,16 @@ contract RelayerTest is DSTest {
             }),
             false
         );
+
+        // We can use the same value as the nextValue
+        oracle.givenQueryReturnResponse(
+            abi.encodePacked(IOracle.nextValue.selector),
+            MockProvider.ReturnData({
+                success: true,
+                data: abi.encode(_oracleValue, true)
+            }),
+            false
+        );
         oracle.givenSelectorReturnResponse(
             Guarded.canCall.selector,
             MockProvider.ReturnData({success: true, data: abi.encode(true)}),

--- a/src/relayer/Relayer.t.sol
+++ b/src/relayer/Relayer.t.sol
@@ -34,7 +34,6 @@ contract TestCollybus is ICollybus {
 
 contract RelayerTest is DSTest {
     CheatCodes internal cheatCodes = CheatCodes(HEVM_ADDRESS);
-    Hevm internal hevm = Hevm(DSTest.HEVM_ADDRESS);
     Relayer internal relayer;
     TestCollybus internal collybus;
     IRelayer.RelayerType internal relayerType =
@@ -416,7 +415,7 @@ contract RelayerTest is DSTest {
         setChainlinkMockReturnedValue(mockChainlinkAggregator, firstValue);
 
         // Forward time to the start
-        hevm.warp(timeStart);
+        cheatCodes.warp(timeStart);
 
         // Run the first execute with revert, Oracle.currentValue and Oracle.nextValue will be equal to firstValue
         testRelayer.executeWithRevert();
@@ -425,7 +424,7 @@ contract RelayerTest is DSTest {
         setChainlinkMockReturnedValue(mockChainlinkAggregator, secondValue);
 
         // Forward time to the next window
-        hevm.warp(timeStart + timeUpdateWindow);
+        cheatCodes.warp(timeStart + timeUpdateWindow);
 
         // Call should not revert
         testRelayer.executeWithRevert();
@@ -440,16 +439,19 @@ contract RelayerTest is DSTest {
         // The current oracle value should still be the first value because fon the previous executeWithRevert()
         // currentValue and nextValue where initialized to `firstValue`
         (int256 value, bool isValid) = chainlinkVP.value();
-        assertTrue(isValid && value == firstValue, "Invalid Oracle value");
+        assertTrue(isValid, "Invalid Oracle value");
+        assertTrue(value == firstValue, "Incorrect Oracle value");
 
         // Forward time to the next window
-        hevm.warp(timeStart + timeUpdateWindow * 2);
+        cheatCodes.warp(timeStart + timeUpdateWindow * 2);
 
         // Call should not revert
         testRelayer.executeWithRevert();
 
         // Make sure the oracle value was updated and is now equal to `secondValue`
         (value, isValid) = chainlinkVP.value();
-        assertTrue(isValid && value == secondValue, "Invalid Oracle value");
+        assertTrue(isValid, "Invalid Oracle value");
+        assertTrue(value == secondValue, "Incorrect Oracle value");
     }
 }
+

--- a/src/relayer/Relayer.t.sol
+++ b/src/relayer/Relayer.t.sol
@@ -453,4 +453,3 @@ contract RelayerTest is DSTest {
         assertTrue(value == secondValue, "Incorrect Oracle value");
     }
 }
-


### PR DESCRIPTION
### Description

Update the execute flow to take into account if `Collybus` is also about to be updated( in the near future) when returning.
This fixes the issue where a **Keeper** was unable to properly update the `Relayer`. 

Updated the `Relayer.execute()` function with a more simple approach that ensures and provides proper support for **Keepers**.

Added tests that cover the **Keeper** execution flow and also ensure the full coverage of the `execute()` and `executeWithRevert()` functions

### Issues

- Closes #125 

### Todo

- [x] Link issues
- [x] Link projects
- [x] Update tests
- [x] Update code
- [x] Comment code
- [x] Test locally
- [x] Update changelog