### PR TITLE
Update how NotionalFinanceValueProvider fetches data from the NotionalFinance contract.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,5 +22,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed execution flow for `executeWithRevert` to allow for oracle updates even if no update to Collybus was performed. Issue [#83](https://github.com/fiatdao/delphi/issues/83)
 - Updated `Relayer.execute()` to return whether a keeper should execute or not the current transaction instead of if Collybus was updated. Fix for issue [#125](https://github.com/fiatdao/delphi/issues/125)
 - Added Market sanity checks for the NotionalFinanceValueProvider Oracle. Fix for issue [#127](https://github.com/fiatdao/delphi/issues/127)
+- Computed settlementDate internally instead of having it as a required parameter when deploying the NotionalFinanceValueProvider Oracle.
 
 ### Removed

--- a/src/factory/NotionalFinanceFactory.sol
+++ b/src/factory/NotionalFinanceFactory.sol
@@ -20,7 +20,6 @@ contract NotionalFinanceFactory {
     /// @param currencyId_ Currency ID(eth = 1, dai = 2, usdc = 3, wbtc = 4)
     /// @param lastImpliedRateDecimals_ Precision of the Notional Market rate.
     /// @param maturity_ Maturity date.
-    /// @param settlementDate_ Settlement date.
     /// @return The address of the Relayer
     function create(
         // Relayer parameters
@@ -33,8 +32,7 @@ contract NotionalFinanceFactory {
         address notionalViewContract_,
         uint256 currencyId_,
         uint256 lastImpliedRateDecimals_,
-        uint256 maturity_,
-        uint256 settlementDate_
+        uint256 maturity_
     ) external returns (address) {
         // Create the oracle that will fetch data from the NotionalFinance contract
         NotionalFinanceValueProvider notionalFinanceValueProvider = new NotionalFinanceValueProvider(
@@ -42,8 +40,7 @@ contract NotionalFinanceFactory {
                 notionalViewContract_,
                 currencyId_,
                 lastImpliedRateDecimals_,
-                maturity_,
-                settlementDate_
+                maturity_
             );
 
         // Create the relayer that manages the oracle and pushes data to Collybus

--- a/src/factory/NotionalFinanceFactory.t.sol
+++ b/src/factory/NotionalFinanceFactory.t.sol
@@ -20,7 +20,6 @@ contract NotionalFinanceFactoryTest is DSTest {
     uint256 private _currencyId = 2;
     uint256 private _lastImpliedRateDecimals = 9;
     uint256 private _maturityDate = 1671840000;
-    uint256 private _settlementDate = 1648512000;
 
     NotionalFinanceFactory private _factory;
 
@@ -42,8 +41,7 @@ contract NotionalFinanceFactoryTest is DSTest {
             _notionalView,
             _currencyId,
             _lastImpliedRateDecimals,
-            _maturityDate,
-            _settlementDate
+            _maturityDate
         );
 
         assertTrue(
@@ -62,8 +60,7 @@ contract NotionalFinanceFactoryTest is DSTest {
             _notionalView,
             _currencyId,
             _lastImpliedRateDecimals,
-            _maturityDate,
-            _settlementDate
+            _maturityDate
         );
 
         Relayer notionalRelayer = Relayer(notionalRelayerAddress);
@@ -84,8 +81,7 @@ contract NotionalFinanceFactoryTest is DSTest {
             _notionalView,
             _currencyId,
             _lastImpliedRateDecimals,
-            _maturityDate,
-            _settlementDate
+            _maturityDate
         );
 
         assertEq(
@@ -123,8 +119,7 @@ contract NotionalFinanceFactoryTest is DSTest {
             _notionalView,
             _currencyId,
             _lastImpliedRateDecimals,
-            _maturityDate,
-            _settlementDate
+            _maturityDate
         );
 
         address oracleAddress = Relayer(notionalRelayerAddress).oracle();
@@ -152,12 +147,6 @@ contract NotionalFinanceFactoryTest is DSTest {
             _maturityDate,
             "Notional Value Provider incorrect maturityDate"
         );
-
-        assertEq(
-            NotionalFinanceValueProvider(oracleAddress).settlementDate(),
-            _settlementDate,
-            "Notional Value Provider incorrect settlementDate"
-        );
     }
 
     function test_create_factoryPassesRelayerPermissions() public {
@@ -170,8 +159,7 @@ contract NotionalFinanceFactoryTest is DSTest {
             _notionalView,
             _currencyId,
             _lastImpliedRateDecimals,
-            _maturityDate,
-            _settlementDate
+            _maturityDate
         );
 
         Relayer notionalRelayer = Relayer(notionalRelayerAddress);
@@ -205,8 +193,7 @@ contract NotionalFinanceFactoryTest is DSTest {
             _notionalView,
             _currencyId,
             _lastImpliedRateDecimals,
-            _maturityDate,
-            _settlementDate
+            _maturityDate
         );
 
         NotionalFinanceValueProvider oracle = NotionalFinanceValueProvider(
@@ -242,8 +229,7 @@ contract NotionalFinanceFactoryTest is DSTest {
             _notionalView,
             invalidCurrencyId,
             _lastImpliedRateDecimals,
-            _maturityDate,
-            _settlementDate
+            _maturityDate
         );
     }
 }

--- a/src/oracle_implementations/discount_rate/NotionalFinance/INotionalView.sol
+++ b/src/oracle_implementations/discount_rate/NotionalFinance/INotionalView.sol
@@ -51,4 +51,9 @@ interface INotionalView {
         uint256 maturity_,
         uint256 settlementDate_
     ) external view returns (MarketParameters memory);
+
+    function getActiveMarkets(uint16 currencyId)
+        external
+        view
+        returns (MarketParameters[] memory);
 }

--- a/src/oracle_implementations/discount_rate/NotionalFinance/NotionalFinanceValueProvider.sol
+++ b/src/oracle_implementations/discount_rate/NotionalFinance/NotionalFinanceValueProvider.sol
@@ -107,9 +107,9 @@ contract NotionalFinanceValueProvider is Oracle, Convert {
     }
 
     /// @notice Retrieve the oracle rate from the NotionalFinance Market
-    function getOracleRate() view internal returns(uint256){
+    function getOracleRate() internal view returns (uint256) {
         uint256 settlementDate = getSettlementDate();
-        // Attempt to retrieve the oracle rate directly by using the maturity and settlement date        
+        // Attempt to retrieve the oracle rate directly by using the maturity and settlement date
         MarketParameters memory marketParams = INotionalView(notionalView)
             .getMarket(uint16(currencyId), maturityDate, settlementDate);
 
@@ -119,7 +119,7 @@ contract NotionalFinanceValueProvider is Oracle, Convert {
                 currencyId,
                 maturityDate,
                 settlementDate
-            );    
+            );
         }
 
         return marketParams.oracleRate;
@@ -127,8 +127,9 @@ contract NotionalFinanceValueProvider is Oracle, Convert {
 
     /// @notice Computes the settlement date as is done in the NotionalFinance contracts
     /// Reference 1: https://github.com/notional-finance/contracts-v2/blob/master/contracts/internal/markets/DateTime.sol#L14
-    /// Reference 2: https://github.com/notional-finance/contracts-v2/blob/d89be9474e181b322480830501728ea625e853d0/contracts/internal/markets/Market.sol#L536
-    function getSettlementDate() view public returns (uint256){
+    /// Reference 2:
+    /// https://github.com/notional-finance/contracts-v2/blob/d89be9474e181b322480830501728ea625e853d0/contracts/internal/markets/Market.sol#L536
+    function getSettlementDate() public view returns (uint256) {
         return block.timestamp - (block.timestamp % QUARTER) + QUARTER;
     }
 }

--- a/src/oracle_implementations/discount_rate/NotionalFinance/NotionalFinanceValueProvider.sol
+++ b/src/oracle_implementations/discount_rate/NotionalFinance/NotionalFinanceValueProvider.sol
@@ -35,10 +35,8 @@ contract NotionalFinanceValueProvider is Oracle, Convert {
 
     address public immutable notionalView;
     uint256 public immutable currencyId;
-
-    uint256 public maturityDate;
-
-    uint256 private immutable lastImpliedRateDecimals;
+    uint256 public immutable maturityDate;
+    uint256 public immutable lastImpliedRateDecimals;
 
     /// @notice Constructs the Value provider contracts with the needed Notional contract data in order to
     /// calculate the annual rate.
@@ -126,7 +124,8 @@ contract NotionalFinanceValueProvider is Oracle, Convert {
     }
 
     /// @notice Computes the settlement date as is done in the NotionalFinance contracts
-    /// Reference 1: https://github.com/notional-finance/contracts-v2/blob/master/contracts/internal/markets/DateTime.sol#L14
+    /// Reference 1:
+    /// https://github.com/notional-finance/contracts-v2/blob/d89be9474e181b322480830501728ea625e853d0/contracts/internal/markets/DateTime.sol#L14
     /// Reference 2:
     /// https://github.com/notional-finance/contracts-v2/blob/d89be9474e181b322480830501728ea625e853d0/contracts/internal/markets/Market.sol#L536
     function getSettlementDate() public view returns (uint256) {

--- a/src/oracle_implementations/discount_rate/NotionalFinance/NotionalFinanceValueProvider.sol
+++ b/src/oracle_implementations/discount_rate/NotionalFinance/NotionalFinanceValueProvider.sol
@@ -2,38 +2,41 @@
 pragma solidity ^0.8.0;
 
 import {Convert} from "../utils/Convert.sol";
-import {INotionalView, MarketParameters} from "./INotionalView.sol";
 import {Oracle} from "../../../oracle/Oracle.sol";
 import "prb-math/contracts/PRBMathSD59x18.sol";
+import {INotionalView} from "./INotionalView.sol";
+import {MarketParameters} from "./INotionalView.sol";
 
 contract NotionalFinanceValueProvider is Oracle, Convert {
-    // @notice Emitted when trying to add pull a value for an expired pool
+    /// @notice Emitted when trying to add pull a value for an expired pool
     error NotionalFinanceValueProvider__getValue_maturityLessThanBlocktime(
         uint256 maturity
     );
 
-    // @notice Emitted when an invalid currencyId is used to deploy the contract
+    /// @notice Emitted when an invalid currencyId is used to deploy the contract
     error NotionalFinanceValueProvider__constructor_invalidCurrencyId(
         uint256 currencyId
     );
 
-    // @notice Emitted when no active market is found for a currencyId
-    error NotionalFinanceValueProvider__getValue_noActiveMarketFound(
-        uint256 currencyId
-    );
-
-    // @notice Emitted when the parameters do not map to an active / initialized Notional Market
+    /// @notice Emitted when the parameters do not map to an active / initialized Notional Market
     error NotionalFinanceValueProvider__getValue_invalidMarketParameters(
         uint256 currencyId,
-        uint256 maturityDate
+        uint256 maturityDate,
+        uint256 settlementDate
     );
 
     // Seconds in a 360 days year as used by Notional in 18 digits precision
     int256 internal constant SECONDS_PER_YEAR = 31104000 * 1e18;
 
+    // Quarter computed as it's defined in the Notional protocol
+    // 3 months , 5 weeks per month, 6 days per week computed in seconds
+    // Reference: https://github.com/notional-finance/contracts-v2/blob/master/contracts/global/Constants.sol#L56
+    uint256 internal constant QUARTER = 3 * 5 * 6 * 86400;
+
     address public immutable notionalView;
     uint256 public immutable currencyId;
-    uint256 public immutable maturityDate;
+
+    uint256 public maturityDate;
 
     uint256 private immutable lastImpliedRateDecimals;
 
@@ -43,7 +46,7 @@ contract NotionalFinanceValueProvider is Oracle, Convert {
     /// @param notionalViewContract_ The address of the deployed notional view contract.
     /// @param currencyId_ Currency ID(eth = 1, dai = 2, usdc = 3, wbtc = 4)
     /// @param lastImpliedRateDecimals_ Precision of the Notional Market rate.
-    /// @param maturity_ Maturity date.
+    /// @param maturityDate_ Maturity date.
     /// @dev reverts if the CurrencyId is bigger than uint16 max value
     constructor(
         // Oracle parameters
@@ -52,7 +55,7 @@ contract NotionalFinanceValueProvider is Oracle, Convert {
         address notionalViewContract_,
         uint256 currencyId_,
         uint256 lastImpliedRateDecimals_,
-        uint256 maturity_
+        uint256 maturityDate_
     ) Oracle(timeUpdateWindow_) {
         if (currencyId_ > type(uint16).max) {
             revert NotionalFinanceValueProvider__constructor_invalidCurrencyId(
@@ -63,7 +66,7 @@ contract NotionalFinanceValueProvider is Oracle, Convert {
         lastImpliedRateDecimals = lastImpliedRateDecimals_;
         notionalView = notionalViewContract_;
         currencyId = currencyId_;
-        maturityDate = maturity_;
+        maturityDate = maturityDate_;
     }
 
     /// @notice Calculates the annual rate used by the FIAT DAO contracts
@@ -79,33 +82,8 @@ contract NotionalFinanceValueProvider is Oracle, Convert {
             );
         }
 
-        // Get all active markets for the set currencyId
-        MarketParameters[] memory activeMarkets = INotionalView(notionalView)
-            .getActiveMarkets(uint16(currencyId));
-
-        // If no active markets are found for the currencyId we need to revert
-        if (activeMarkets.length == 0) {
-            revert NotionalFinanceValueProvider__getValue_noActiveMarketFound(
-                currencyId
-            );
-        }
-
-        uint256 oracleRate = 0;
-        // We need to iterate though all the active markets and match via the maturityDate
-        for (uint256 idx = 0; idx < activeMarkets.length; ++idx) {
-            if (activeMarkets[idx].maturity == maturityDate) {
-                oracleRate = activeMarkets[idx].oracleRate;
-                break;
-            }
-        }
-
-        // If the oracleRate is not set it means there are no markets for our currencyId and maturityData
-        if (oracleRate <= 0) {
-            revert NotionalFinanceValueProvider__getValue_invalidMarketParameters(
-                currencyId,
-                maturityDate
-            );
-        }
+        // Retrieve the oracle rate from Notional
+        uint256 oracleRate = getOracleRate();
 
         // Convert rate per annum to 18 digits precision.
         uint256 ratePerAnnum = uconvert(
@@ -126,5 +104,31 @@ contract NotionalFinanceValueProvider is Oracle, Convert {
 
         // The result is a 59.18 fixed-point number.
         return discreteRateD59x18;
+    }
+
+    /// @notice Retrieve the oracle rate from the NotionalFinance Market
+    function getOracleRate() view internal returns(uint256){
+        uint256 settlementDate = getSettlementDate();
+        // Attempt to retrieve the oracle rate directly by using the maturity and settlement date        
+        MarketParameters memory marketParams = INotionalView(notionalView)
+            .getMarket(uint16(currencyId), maturityDate, settlementDate);
+
+        // If we find an active market we can return the oracle rate
+        if (marketParams.oracleRate <= 0) {
+            revert NotionalFinanceValueProvider__getValue_invalidMarketParameters(
+                currencyId,
+                maturityDate,
+                settlementDate
+            );    
+        }
+
+        return marketParams.oracleRate;
+    }
+
+    /// @notice Computes the settlement date as is done in the NotionalFinance contracts
+    /// Reference 1: https://github.com/notional-finance/contracts-v2/blob/master/contracts/internal/markets/DateTime.sol#L14
+    /// Reference 2: https://github.com/notional-finance/contracts-v2/blob/d89be9474e181b322480830501728ea625e853d0/contracts/internal/markets/Market.sol#L536
+    function getSettlementDate() view public returns (uint256){
+        return block.timestamp - (block.timestamp % QUARTER) + QUARTER;
     }
 }

--- a/src/oracle_implementations/discount_rate/NotionalFinance/NotionalFinanceValueProvider.sol
+++ b/src/oracle_implementations/discount_rate/NotionalFinance/NotionalFinanceValueProvider.sol
@@ -113,7 +113,7 @@ contract NotionalFinanceValueProvider is Oracle, Convert {
         MarketParameters memory marketParams = INotionalView(notionalView)
             .getMarket(uint16(currencyId), maturityDate, settlementDate);
 
-        // If we find an active market we can return the oracle rate
+        // If we find an active market we can return the oracle rate otherwise we revert
         if (marketParams.oracleRate <= 0) {
             revert NotionalFinanceValueProvider__getValue_invalidMarketParameters(
                 currencyId,

--- a/src/oracle_implementations/discount_rate/NotionalFinance/NotionalFinanceValueProvider.t.sol
+++ b/src/oracle_implementations/discount_rate/NotionalFinance/NotionalFinanceValueProvider.t.sol
@@ -27,8 +27,6 @@ contract NotionalFinanceValueProviderTest is DSTest {
         // block: 13979660
         mockNotionalView = new MockProvider();
 
-
-
         notionalVP = new NotionalFinanceValueProvider(
             // Oracle arguments
             // Time update window
@@ -71,18 +69,20 @@ contract NotionalFinanceValueProviderTest is DSTest {
             ),
             MockProvider.ReturnData({
                 success: true,
-                data: abi.encode(MarketParameters({
-                    storageSlot: bytes32(
-                        0xc0ddee3e85a71c2541e1bd9f87cf75833c3860ea32afc5fab9589fd51748147b
-                    ),
-                    maturity: _maturityDate,
-                    totalfCash: int256(7134342186012091),
-                    totalAssetCash: int256(222912257923357058),
-                    totalLiquidity: int256(221856382336730813),
-                    lastImpliedRate: uint256(88688026),
-                    oracleRate: uint256(88688026),
-                    previousTradeTime: uint256(1641600791)
-                }))
+                data: abi.encode(
+                    MarketParameters({
+                        storageSlot: bytes32(
+                            0xc0ddee3e85a71c2541e1bd9f87cf75833c3860ea32afc5fab9589fd51748147b
+                        ),
+                        maturity: _maturityDate,
+                        totalfCash: int256(7134342186012091),
+                        totalAssetCash: int256(222912257923357058),
+                        totalLiquidity: int256(221856382336730813),
+                        lastImpliedRate: uint256(88688026),
+                        oracleRate: uint256(88688026),
+                        previousTradeTime: uint256(1641600791)
+                    })
+                )
             }),
             false
         );
@@ -103,29 +103,31 @@ contract NotionalFinanceValueProviderTest is DSTest {
     function test_getValue_failsWithInvalidMarketParameters() public {
         // Update the mock to return an un-initialized market
         mockNotionalView.givenQueryReturnResponse(
-        abi.encodeWithSelector(
-            INotionalView.getMarket.selector,
-            _currencyId,
-            _maturityDate,
-            notionalVP.getSettlementDate()
-        ),
-        MockProvider.ReturnData({
-            success: true,
-            data: abi.encode(MarketParameters({
-                storageSlot: bytes32(
-                    0xc0ddee3e85a71c2541e1bd9f87cf75833c3860ea32afc5fab9589fd51748147b
-                ),
-                maturity: _maturityDate,
-                totalfCash: int256(0),
-                totalAssetCash: int256(0),
-                totalLiquidity: int256(0),
-                lastImpliedRate: uint256(0),
-                oracleRate: uint256(0),
-                previousTradeTime: uint256(0)
-            }))
-        }),
-        false
-    );
+            abi.encodeWithSelector(
+                INotionalView.getMarket.selector,
+                _currencyId,
+                _maturityDate,
+                notionalVP.getSettlementDate()
+            ),
+            MockProvider.ReturnData({
+                success: true,
+                data: abi.encode(
+                    MarketParameters({
+                        storageSlot: bytes32(
+                            0xc0ddee3e85a71c2541e1bd9f87cf75833c3860ea32afc5fab9589fd51748147b
+                        ),
+                        maturity: _maturityDate,
+                        totalfCash: int256(0),
+                        totalAssetCash: int256(0),
+                        totalLiquidity: int256(0),
+                        lastImpliedRate: uint256(0),
+                        oracleRate: uint256(0),
+                        previousTradeTime: uint256(0)
+                    })
+                )
+            }),
+            false
+        );
 
         // Call should revert because of the invalid market
         cheatCodes.expectRevert(

--- a/src/oracle_implementations/discount_rate/NotionalFinance/NotionalFinanceValueProvider.t.sol
+++ b/src/oracle_implementations/discount_rate/NotionalFinance/NotionalFinanceValueProvider.t.sol
@@ -19,7 +19,6 @@ contract NotionalFinanceValueProviderTest is DSTest {
 
     uint16 internal _currencyId = 2;
     uint256 internal _maturityDate = 1671840000;
-    uint256 internal _settlementDate = 1648512000;
     uint256 internal _timeUpdateWindow = 100; // seconds
 
     function setUp() public {
@@ -27,30 +26,32 @@ contract NotionalFinanceValueProviderTest is DSTest {
         // 0x1344A36A1B56144C3Bc62E7757377D288fDE0369
         // block: 13979660
         mockNotionalView = new MockProvider();
+
+        MarketParameters[] memory activeMarkets = new MarketParameters[](1);
+        activeMarkets[0] = MarketParameters({
+            storageSlot: bytes32(
+                0xc0ddee3e85a71c2541e1bd9f87cf75833c3860ea32afc5fab9589fd51748147b
+            ),
+            maturity: _maturityDate,
+            totalfCash: int256(7134342186012091),
+            totalAssetCash: int256(222912257923357058),
+            totalLiquidity: int256(221856382336730813),
+            lastImpliedRate: uint256(88688026),
+            oracleRate: uint256(88688026),
+            previousTradeTime: uint256(1641600791)
+        });
+
+        emit log_uint(activeMarkets.length);
+
         mockNotionalView.givenQueryReturnResponse(
             // Used Parameters are: currency ID, maturity date and settlement date.
             abi.encodeWithSelector(
-                INotionalView.getMarket.selector,
-                _currencyId,
-                uint256(1671840000),
-                uint256(1648512000)
+                INotionalView.getActiveMarkets.selector,
+                _currencyId
             ),
             MockProvider.ReturnData({
                 success: true,
-                data: abi.encode(
-                    MarketParameters({
-                        storageSlot: bytes32(
-                            0xc0ddee3e85a71c2541e1bd9f87cf75833c3860ea32afc5fab9589fd51748147b
-                        ),
-                        maturity: uint256(1671840000),
-                        totalfCash: int256(7134342186012091),
-                        totalAssetCash: int256(222912257923357058),
-                        totalLiquidity: int256(221856382336730813),
-                        lastImpliedRate: uint256(88688026),
-                        oracleRate: uint256(88688026),
-                        previousTradeTime: uint256(1641600791)
-                    })
-                )
+                data: abi.encode(activeMarkets)
             }),
             false
         );
@@ -63,8 +64,7 @@ contract NotionalFinanceValueProviderTest is DSTest {
             address(mockNotionalView),
             _currencyId,
             9,
-            _maturityDate,
-            _settlementDate
+            _maturityDate
         );
     }
 
@@ -87,12 +87,7 @@ contract NotionalFinanceValueProviderTest is DSTest {
         assertEq(notionalVP.maturityDate(), _maturityDate);
     }
 
-    function test_check_settlementDate() public {
-        // Check the settlement date
-        assertEq(notionalVP.settlementDate(), _settlementDate);
-    }
-
-    function test_getValue() public {
+    function test_getValue123() public {
         // Expected value is the lastImpliedRate(1e9 precision) in 1e18 precision
         int256 expectedValue = 2851338287;
 
@@ -108,29 +103,29 @@ contract NotionalFinanceValueProviderTest is DSTest {
 
     function test_getValue_failsWithInvalidMarketParameters() public {
         // Update the mock to return an un-initialized market
+        MarketParameters[] memory activeMarkets = new MarketParameters[](1);
+        activeMarkets[0] = MarketParameters({
+            storageSlot: bytes32(
+                0xc0ddee3e85a71c2541e1bd9f87cf75833c3860ea32afc5fab9589fd51748147b
+            ),
+            maturity: _maturityDate,
+            totalfCash: int256(0),
+            totalAssetCash: int256(0),
+            totalLiquidity: int256(0),
+            lastImpliedRate: uint256(0),
+            oracleRate: uint256(0),
+            previousTradeTime: uint256(0)
+        });
+
         mockNotionalView.givenQueryReturnResponse(
+            // Used Parameters are: currency ID, maturity date and settlement date.
             abi.encodeWithSelector(
-                INotionalView.getMarket.selector,
-                _currencyId,
-                uint256(1671840000),
-                uint256(1648512000)
+                INotionalView.getActiveMarkets.selector,
+                _currencyId
             ),
             MockProvider.ReturnData({
                 success: true,
-                data: abi.encode(
-                    MarketParameters({
-                        storageSlot: bytes32(
-                            0xc0ddee3e85a71c2541e1bd9f87cf75833c3860ea32afc5fab9589fd51748147b
-                        ),
-                        maturity: uint256(1671840000),
-                        totalfCash: int256(0),
-                        totalAssetCash: int256(0),
-                        totalLiquidity: int256(0),
-                        lastImpliedRate: uint256(0),
-                        oracleRate: uint256(0),
-                        previousTradeTime: uint256(0)
-                    })
-                )
+                data: abi.encode(activeMarkets)
             }),
             false
         );
@@ -142,8 +137,35 @@ contract NotionalFinanceValueProviderTest is DSTest {
                     .NotionalFinanceValueProvider__getValue_invalidMarketParameters
                     .selector,
                 _currencyId,
-                uint256(1671840000),
-                uint256(1648512000)
+                _maturityDate
+            )
+        );
+        notionalVP.getValue();
+    }
+
+    function test_getValue_failsWithNoActiveMarkets() public {
+        // Update the mock to return an un-initialized market
+        MarketParameters[] memory activeMarkets;
+        mockNotionalView.givenQueryReturnResponse(
+            // Used Parameters are: currency ID, maturity date and settlement date.
+            abi.encodeWithSelector(
+                INotionalView.getActiveMarkets.selector,
+                _currencyId
+            ),
+            MockProvider.ReturnData({
+                success: true,
+                data: abi.encode(activeMarkets)
+            }),
+            false
+        );
+
+        // Call should revert because of the invalid market
+        cheatCodes.expectRevert(
+            abi.encodeWithSelector(
+                NotionalFinanceValueProvider
+                    .NotionalFinanceValueProvider__getValue_noActiveMarketFound
+                    .selector,
+                _currencyId
             )
         );
         notionalVP.getValue();

--- a/src/oracle_implementations/discount_rate/NotionalFinance/NotionalFinanceValueProvider.t.sol
+++ b/src/oracle_implementations/discount_rate/NotionalFinance/NotionalFinanceValueProvider.t.sol
@@ -58,7 +58,7 @@ contract NotionalFinanceValueProviderTest is DSTest {
         assertEq(notionalVP.maturityDate(), _maturityDate);
     }
 
-    function test_getValue123() public {
+    function test_getValue() public {
         mockNotionalView.givenQueryReturnResponse(
             // Used Parameters are: currency ID, maturity date and settlement date.
             abi.encodeWithSelector(


### PR DESCRIPTION
### Description

Changed how `NotionalFinanceValueProvider` fetches data by removing the `settlementDate` as a immutable and instead we compute it internally.

This is done the same as in the Notional contracts.
Source 1 and 2: [here](https://github.com/notional-finance/contracts-v2/blob/master/contracts/internal/markets/DateTime.sol#L14) and [here](https://github.com/notional-finance/contracts-v2/blob/d89be9474e181b322480830501728ea625e853d0/contracts/internal/markets/Market.sol#L536
).

This removes the need of manually updating the `settlementDate` each time it changes while the Market is active.

Our implementation:
```
    function getSettlementDate() public view returns (uint256) {
        return block.timestamp - (block.timestamp % QUARTER) + QUARTER;
    }
```

### Issues

### Todo

- [ ] Link issues
- [x] Link projects
- [x] Update tests
- [x] Update code
- [x] Comment code
- [x] Test locally
- [x] Update changelog