### PR TITLE
Fix/notional oracle property rename

### DIFF
--- a/src/factory/NotionalFinanceFactory.sol
+++ b/src/factory/NotionalFinanceFactory.sol
@@ -16,9 +16,9 @@ contract NotionalFinanceFactory {
     /// @param minimumPercentageDeltaValue_ Minimum delta value used to determine when to
     /// push data to Collybus
     /// @param timeUpdateWindow_ Minimum time between updates of the value
-    /// @param notionalViewContract_ The address of the deployed notional view contract.
+    /// @param notional_ The address of the deployed notional contract
     /// @param currencyId_ Currency ID(eth = 1, dai = 2, usdc = 3, wbtc = 4)
-    /// @param lastImpliedRateDecimals_ Precision of the Notional Market rate.
+    /// @param oracleRateDecimals_ Precision of the Notional oracle rate
     /// @param maturity_ Maturity date.
     /// @return The address of the Relayer
     function create(
@@ -29,17 +29,17 @@ contract NotionalFinanceFactory {
         // Oracle parameters
         uint256 timeUpdateWindow_,
         // Notional specific parameters, see NotionalFinanceValueProvider for more info
-        address notionalViewContract_,
+        address notional_,
         uint256 currencyId_,
-        uint256 lastImpliedRateDecimals_,
+        uint256 oracleRateDecimals_,
         uint256 maturity_
     ) external returns (address) {
         // Create the oracle that will fetch data from the NotionalFinance contract
         NotionalFinanceValueProvider notionalFinanceValueProvider = new NotionalFinanceValueProvider(
                 timeUpdateWindow_,
-                notionalViewContract_,
+                notional_,
                 currencyId_,
-                lastImpliedRateDecimals_,
+                oracleRateDecimals_,
                 maturity_
             );
 

--- a/src/factory/NotionalFinanceFactory.t.sol
+++ b/src/factory/NotionalFinanceFactory.t.sol
@@ -16,9 +16,9 @@ contract NotionalFinanceFactoryTest is DSTest {
     uint256 private _tokenId = 1;
     uint256 private _minimumPercentageDeltaValue = 25;
 
-    address private _notionalView;
+    address private _notional;
     uint256 private _currencyId = 2;
-    uint256 private _lastImpliedRateDecimals = 9;
+    uint256 private _oracleRateDecimals = 9;
     uint256 private _maturityDate = 1671840000;
 
     NotionalFinanceFactory private _factory;
@@ -38,9 +38,9 @@ contract NotionalFinanceFactoryTest is DSTest {
             _tokenId,
             _minimumPercentageDeltaValue,
             _oracleUpdateWindow,
-            _notionalView,
+            _notional,
             _currencyId,
-            _lastImpliedRateDecimals,
+            _oracleRateDecimals,
             _maturityDate
         );
 
@@ -57,9 +57,9 @@ contract NotionalFinanceFactoryTest is DSTest {
             _tokenId,
             _minimumPercentageDeltaValue,
             _oracleUpdateWindow,
-            _notionalView,
+            _notional,
             _currencyId,
-            _lastImpliedRateDecimals,
+            _oracleRateDecimals,
             _maturityDate
         );
 
@@ -78,9 +78,9 @@ contract NotionalFinanceFactoryTest is DSTest {
             _tokenId,
             _minimumPercentageDeltaValue,
             _oracleUpdateWindow,
-            _notionalView,
+            _notional,
             _currencyId,
-            _lastImpliedRateDecimals,
+            _oracleRateDecimals,
             _maturityDate
         );
 
@@ -116,9 +116,9 @@ contract NotionalFinanceFactoryTest is DSTest {
             _tokenId,
             _minimumPercentageDeltaValue,
             _oracleUpdateWindow,
-            _notionalView,
+            _notional,
             _currencyId,
-            _lastImpliedRateDecimals,
+            _oracleRateDecimals,
             _maturityDate
         );
 
@@ -131,8 +131,8 @@ contract NotionalFinanceFactoryTest is DSTest {
         );
 
         assertEq(
-            NotionalFinanceValueProvider(oracleAddress).notionalView(),
-            _notionalView,
+            NotionalFinanceValueProvider(oracleAddress).notional(),
+            _notional,
             "Notional Value Provider incorrect notionalView"
         );
 
@@ -156,9 +156,9 @@ contract NotionalFinanceFactoryTest is DSTest {
             _tokenId,
             _minimumPercentageDeltaValue,
             _oracleUpdateWindow,
-            _notionalView,
+            _notional,
             _currencyId,
-            _lastImpliedRateDecimals,
+            _oracleRateDecimals,
             _maturityDate
         );
 
@@ -190,9 +190,9 @@ contract NotionalFinanceFactoryTest is DSTest {
             _tokenId,
             _minimumPercentageDeltaValue,
             _oracleUpdateWindow,
-            _notionalView,
+            _notional,
             _currencyId,
-            _lastImpliedRateDecimals,
+            _oracleRateDecimals,
             _maturityDate
         );
 
@@ -226,9 +226,9 @@ contract NotionalFinanceFactoryTest is DSTest {
             _tokenId,
             _minimumPercentageDeltaValue,
             _oracleUpdateWindow,
-            _notionalView,
+            _notional,
             invalidCurrencyId,
-            _lastImpliedRateDecimals,
+            _oracleRateDecimals,
             _maturityDate
         );
     }

--- a/src/oracle_implementations/discount_rate/NotionalFinance/NotionalFinanceValueProvider.sol
+++ b/src/oracle_implementations/discount_rate/NotionalFinance/NotionalFinanceValueProvider.sol
@@ -41,9 +41,9 @@ contract NotionalFinanceValueProvider is Oracle, Convert {
     /// @notice Constructs the Value provider contracts with the needed Notional contract data in order to
     /// calculate the annual rate.
     /// @param timeUpdateWindow_ Minimum time between updates of the value
-    /// @param notional_ The address of the deployed notional contract.
+    /// @param notional_ The address of the deployed notional contract
     /// @param currencyId_ Currency ID(eth = 1, dai = 2, usdc = 3, wbtc = 4)
-    /// @param oracleRateDecimals_ Precision of the Notional oracle rate.
+    /// @param oracleRateDecimals_ Precision of the Notional oracle rate
     /// @param maturityDate_ Maturity date.
     /// @dev reverts if the CurrencyId is bigger than uint16 max value
     constructor(

--- a/src/oracle_implementations/discount_rate/NotionalFinance/NotionalFinanceValueProvider.sol
+++ b/src/oracle_implementations/discount_rate/NotionalFinance/NotionalFinanceValueProvider.sol
@@ -33,26 +33,26 @@ contract NotionalFinanceValueProvider is Oracle, Convert {
     // Reference: https://github.com/notional-finance/contracts-v2/blob/master/contracts/global/Constants.sol#L56
     uint256 internal constant QUARTER = 3 * 5 * 6 * 86400;
 
-    address public immutable notionalView;
+    address public immutable notional;
     uint256 public immutable currencyId;
     uint256 public immutable maturityDate;
-    uint256 public immutable lastImpliedRateDecimals;
+    uint256 public immutable oracleRateDecimals;
 
     /// @notice Constructs the Value provider contracts with the needed Notional contract data in order to
     /// calculate the annual rate.
     /// @param timeUpdateWindow_ Minimum time between updates of the value
-    /// @param notionalViewContract_ The address of the deployed notional view contract.
+    /// @param notional_ The address of the deployed notional contract.
     /// @param currencyId_ Currency ID(eth = 1, dai = 2, usdc = 3, wbtc = 4)
-    /// @param lastImpliedRateDecimals_ Precision of the Notional Market rate.
+    /// @param oracleRateDecimals_ Precision of the Notional oracle rate.
     /// @param maturityDate_ Maturity date.
     /// @dev reverts if the CurrencyId is bigger than uint16 max value
     constructor(
         // Oracle parameters
         uint256 timeUpdateWindow_,
         // Notional specific parameters
-        address notionalViewContract_,
+        address notional_,
         uint256 currencyId_,
-        uint256 lastImpliedRateDecimals_,
+        uint256 oracleRateDecimals_,
         uint256 maturityDate_
     ) Oracle(timeUpdateWindow_) {
         if (currencyId_ > type(uint16).max) {
@@ -61,8 +61,8 @@ contract NotionalFinanceValueProvider is Oracle, Convert {
             );
         }
 
-        lastImpliedRateDecimals = lastImpliedRateDecimals_;
-        notionalView = notionalViewContract_;
+        oracleRateDecimals = oracleRateDecimals_;
+        notional = notional_;
         currencyId = currencyId_;
         maturityDate = maturityDate_;
     }
@@ -86,7 +86,7 @@ contract NotionalFinanceValueProvider is Oracle, Convert {
         // Convert rate per annum to 18 digits precision.
         uint256 ratePerAnnum = uconvert(
             oracleRate,
-            lastImpliedRateDecimals,
+            oracleRateDecimals,
             18
         );
 
@@ -108,7 +108,7 @@ contract NotionalFinanceValueProvider is Oracle, Convert {
     function getOracleRate() internal view returns (uint256) {
         uint256 settlementDate = getSettlementDate();
         // Attempt to retrieve the oracle rate directly by using the maturity and settlement date
-        MarketParameters memory marketParams = INotionalView(notionalView)
+        MarketParameters memory marketParams = INotionalView(notional)
             .getMarket(uint16(currencyId), maturityDate, settlementDate);
 
         // If we find an active market we can return the oracle rate otherwise we revert

--- a/src/oracle_implementations/discount_rate/NotionalFinance/NotionalFinanceValueProvider.sol
+++ b/src/oracle_implementations/discount_rate/NotionalFinance/NotionalFinanceValueProvider.sol
@@ -39,7 +39,7 @@ contract NotionalFinanceValueProvider is Oracle, Convert {
     uint256 public immutable oracleRateDecimals;
 
     /// @notice Constructs the Value provider contracts with the needed Notional contract data in order to
-    /// calculate the annual rate.
+    /// calculate the per-second rate.
     /// @param timeUpdateWindow_ Minimum time between updates of the value
     /// @param notional_ The address of the deployed notional contract
     /// @param currencyId_ Currency ID(eth = 1, dai = 2, usdc = 3, wbtc = 4)

--- a/src/oracle_implementations/discount_rate/NotionalFinance/NotionalFinanceValueProvider.sol
+++ b/src/oracle_implementations/discount_rate/NotionalFinance/NotionalFinanceValueProvider.sol
@@ -84,11 +84,7 @@ contract NotionalFinanceValueProvider is Oracle, Convert {
         uint256 oracleRate = getOracleRate();
 
         // Convert rate per annum to 18 digits precision.
-        uint256 ratePerAnnum = uconvert(
-            oracleRate,
-            oracleRateDecimals,
-            18
-        );
+        uint256 ratePerAnnum = uconvert(oracleRate, oracleRateDecimals, 18);
 
         // Convert per annum to per second rate
         int256 ratePerSecondD59x18 = PRBMathSD59x18.div(

--- a/src/oracle_implementations/discount_rate/NotionalFinance/NotionalFinanceValueProvider.t.sol
+++ b/src/oracle_implementations/discount_rate/NotionalFinance/NotionalFinanceValueProvider.t.sol
@@ -13,7 +13,7 @@ import {NotionalFinanceValueProvider} from "./NotionalFinanceValueProvider.sol";
 contract NotionalFinanceValueProviderTest is DSTest {
     CheatCodes internal cheatCodes = CheatCodes(HEVM_ADDRESS);
 
-    MockProvider internal mockNotionalView;
+    MockProvider internal mockNotional;
 
     NotionalFinanceValueProvider internal notionalVP;
 
@@ -25,14 +25,14 @@ contract NotionalFinanceValueProviderTest is DSTest {
         // Values taken from interrogating the active markets via the Notional View Contract deployed at
         // 0x1344A36A1B56144C3Bc62E7757377D288fDE0369
         // block: 13979660
-        mockNotionalView = new MockProvider();
+        mockNotional = new MockProvider();
 
         notionalVP = new NotionalFinanceValueProvider(
             // Oracle arguments
             // Time update window
             _timeUpdateWindow,
             // Notional Finance arguments
-            address(mockNotionalView),
+            address(mockNotional),
             _currencyId,
             9,
             _maturityDate
@@ -43,9 +43,9 @@ contract NotionalFinanceValueProviderTest is DSTest {
         assertTrue(address(notionalVP) != address(0));
     }
 
-    function test_check_notionalView() public {
+    function test_check_notional() public {
         // Check the address of the notional view contract
-        assertEq(notionalVP.notionalView(), address(mockNotionalView));
+        assertEq(notionalVP.notional(), address(mockNotional));
     }
 
     function test_check_currencyId() public {
@@ -59,7 +59,7 @@ contract NotionalFinanceValueProviderTest is DSTest {
     }
 
     function test_getValue() public {
-        mockNotionalView.givenQueryReturnResponse(
+        mockNotional.givenQueryReturnResponse(
             // Used Parameters are: currency ID, maturity date and settlement date.
             abi.encodeWithSelector(
                 INotionalView.getMarket.selector,
@@ -102,7 +102,7 @@ contract NotionalFinanceValueProviderTest is DSTest {
 
     function test_getValue_failsWithInvalidMarketParameters() public {
         // Update the mock to return an un-initialized market
-        mockNotionalView.givenQueryReturnResponse(
+        mockNotional.givenQueryReturnResponse(
             abi.encodeWithSelector(
                 INotionalView.getMarket.selector,
                 _currencyId,


### PR DESCRIPTION
### Description

Renamed two properties in the `NotionalFinanceValueProvider` contract:
`notionalView` was renamed to 'notional'
`lastImpliedRateDecimals` was renamed to `oracleRateDecimals`

### Issues

- Closes #131 

### Todo

- [x] Link issues
- [x] Link projects
- [x] Update tests
- [x] Update code
- [x] Comment code
- [x] Test locally
- [ ] Update changelog