### PR TITLE
Updated the Yield oracle and factory.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,5 +23,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated `Relayer.execute()` to return whether a keeper should execute or not the current transaction instead of if Collybus was updated. Fix for issue [#125](https://github.com/fiatdao/delphi/issues/125)
 - Added Market sanity checks for the NotionalFinanceValueProvider Oracle. Fix for issue [#127](https://github.com/fiatdao/delphi/issues/127)
 - Computed settlementDate internally instead of having it as a required parameter when deploying the NotionalFinanceValueProvider Oracle.
+- YieldValueProvider `getValue()` can be called only by the oracle contract.
 
 ### Removed

--- a/src/factory/YieldFactory.sol
+++ b/src/factory/YieldFactory.sol
@@ -16,6 +16,8 @@ contract YieldFactory {
     /// @param poolAddress_ Address of the pool
     /// @param maturity_ Expiration of the pool
     /// @param timeScale_ Time scale used on this pool (i.e. 1/(timeStretch*secondsPerYear)) in 59x18 fixed point
+    /// @param cumulativeBalanceTimestamp_ The time at which the provided balance ratio was computed
+    /// @param cumulativeBalancesRatio_ The current balance ratio that will be used as a starting value
     /// @return The address of the Relayer
     function create(
         // Relayer parameters
@@ -27,13 +29,17 @@ contract YieldFactory {
         // Yield specific parameters, see YieldValueProvider for more info
         address poolAddress_,
         uint256 maturity_,
-        int256 timeScale_
+        int256 timeScale_,
+        uint256 cumulativeBalanceTimestamp_,
+        uint256 cumulativeBalancesRatio_
     ) public returns (address) {
         YieldValueProvider yieldValueProvider = new YieldValueProvider(
             timeUpdateWindow_,
             poolAddress_,
             maturity_,
-            timeScale_
+            timeScale_,
+            cumulativeBalanceTimestamp_,
+            cumulativeBalancesRatio_
         );
 
         // Create the relayer that manages the oracle and pushes data to Collybus

--- a/src/factory/YieldFactory.sol
+++ b/src/factory/YieldFactory.sol
@@ -17,7 +17,9 @@ contract YieldFactory {
     /// @param maturity_ Expiration of the pool
     /// @param timeScale_ Time scale used on this pool (i.e. 1/(timeStretch*secondsPerYear)) in 59x18 fixed point
     /// @param cumulativeBalanceTimestamp_ The time at which the provided balance ratio was computed
-    /// @param cumulativeBalancesRatio_ The current balance ratio that will be used as a starting value
+    /// @param cumulativeBalancesRatio_ The cumulative balance ratio at cumulativeBalanceTimestamp_
+    /// @dev The cumulative balance ratio from the yield pool by calling cumulativeBalancesRatio() and
+    /// the timestamp is retrieved by calling the getCache() function
     /// @return The address of the Relayer
     function create(
         // Relayer parameters

--- a/src/factory/YieldFactory.t.sol
+++ b/src/factory/YieldFactory.t.sol
@@ -8,10 +8,11 @@ import {YieldFactory} from "./YieldFactory.sol";
 import {IYieldPool} from "../oracle_implementations/discount_rate/Yield/IYieldPool.sol";
 import {YieldValueProvider} from "../oracle_implementations/discount_rate/Yield/YieldValueProvider.sol";
 
+import {Convert} from "../oracle_implementations/discount_rate/utils/Convert.sol";
 import {Relayer} from "../relayer/Relayer.sol";
 import {IRelayer} from "../relayer/IRelayer.sol";
 
-contract YieldFactoryTest is DSTest {
+contract YieldFactoryTest is DSTest, Convert {
     address private _collybusAddress = address(0xC011b005);
     uint256 private _oracleUpdateWindow = 1 * 3600;
     uint256 private _tokenId = 1;
@@ -19,6 +20,8 @@ contract YieldFactoryTest is DSTest {
 
     uint256 private _maturity = 1648177200;
     int256 private _timeScale = 3168808781; // computed from 58454204609 which is in 64.64 format
+    uint256 private _startBlockTimestamp = 1;
+    uint256 private _startCumulativeBalanceRatio = 1;
 
     YieldFactory private _factory;
 
@@ -53,7 +56,9 @@ contract YieldFactoryTest is DSTest {
             _oracleUpdateWindow,
             address(yieldPool),
             _maturity,
-            _timeScale
+            _timeScale,
+            _startBlockTimestamp,
+            _startCumulativeBalanceRatio
         );
 
         assertTrue(
@@ -85,7 +90,9 @@ contract YieldFactoryTest is DSTest {
             _oracleUpdateWindow,
             address(yieldPool),
             _maturity,
-            _timeScale
+            _timeScale,
+            _startBlockTimestamp,
+            _startCumulativeBalanceRatio
         );
 
         assertTrue(
@@ -117,7 +124,9 @@ contract YieldFactoryTest is DSTest {
             _oracleUpdateWindow,
             address(yieldPool),
             _maturity,
-            _timeScale
+            _timeScale,
+            _startBlockTimestamp,
+            _startCumulativeBalanceRatio
         );
 
         address yieldOracleAddress = Relayer(yieldRelayerAddress).oracle();
@@ -146,6 +155,18 @@ contract YieldFactoryTest is DSTest {
             _timeScale,
             "Yield Value Provider incorrect timeScale"
         );
+
+        assertEq(
+            YieldValueProvider(yieldOracleAddress).cumulativeBalanceRatioLast(),
+            uconvert(_startCumulativeBalanceRatio, 27, 18),
+            "Yield Value Provider incorrect cumulativeBalanceRatioLast"
+        );
+
+        assertEq(
+            YieldValueProvider(yieldOracleAddress).balanceTimestampLast(),
+            _startBlockTimestamp,
+            "Yield Value Provider incorrect balanceTimestampLast"
+        );
     }
 
     function test_create_validateRelayerProperties() public {
@@ -171,7 +192,9 @@ contract YieldFactoryTest is DSTest {
             _oracleUpdateWindow,
             address(yieldPool),
             _maturity,
-            _timeScale
+            _timeScale,
+            _startBlockTimestamp,
+            _startCumulativeBalanceRatio
         );
 
         // Test that properties are correctly set
@@ -223,7 +246,9 @@ contract YieldFactoryTest is DSTest {
             _oracleUpdateWindow,
             address(yieldPool),
             _maturity,
-            _timeScale
+            _timeScale,
+            _startBlockTimestamp,
+            _startCumulativeBalanceRatio
         );
 
         YieldValueProvider yieldValueProvider = YieldValueProvider(

--- a/src/oracle_implementations/discount_rate/Yield/YieldValueProvider.sol
+++ b/src/oracle_implementations/discount_rate/Yield/YieldValueProvider.sol
@@ -30,7 +30,9 @@ contract YieldValueProvider is Oracle, Convert {
     /// @param maturity_ Expiration of the pool
     /// @param timeScale_ Time scale used on this pool (i.e. 1/(timeStretch*secondsPerYear)) in 59x18 fixed point
     /// @param cumulativeBalanceTimestamp_ The time at which the provided balance ratio was computed
-    /// @param cumulativeBalancesRatio_ The current balance ratio that will be used as a starting value
+    /// @param cumulativeBalancesRatio_ The cumulative balance ratio at cumulativeBalanceTimestamp_
+    /// @dev The cumulative balance ratio from the yield pool by calling cumulativeBalancesRatio() and
+    /// the timestamp is retrieved by calling the getCache() function
     constructor(
         // Oracle parameters
         uint256 timeUpdateWindow_,

--- a/src/oracle_implementations/discount_rate/Yield/YieldValueProvider.t.sol
+++ b/src/oracle_implementations/discount_rate/Yield/YieldValueProvider.t.sol
@@ -4,26 +4,60 @@ pragma solidity ^0.8.0;
 import "ds-test/test.sol";
 import "../../../test/utils/Caller.sol";
 import {Hevm} from "../../../test/utils/Hevm.sol";
+import {CheatCodes} from "../../../test/utils/CheatCodes.sol";
 import {Convert} from "../utils/Convert.sol";
 import {MockProvider} from "@cleanunicorn/mockprovider/src/MockProvider.sol";
 import {YieldValueProvider} from "./YieldValueProvider.sol";
 import {IYieldPool} from "./IYieldPool.sol";
 
+contract YieldValueProviderHelper is YieldValueProvider {
+    constructor(
+        // Oracle parameters
+        uint256 timeUpdateWindow_,
+        // Yield specific parameters
+        address poolAddress_,
+        uint256 maturity_,
+        int256 timeScale_,
+        uint256 timestamp_,
+        uint256 balancesRatio_
+    )
+        YieldValueProvider(
+            timeUpdateWindow_,
+            poolAddress_,
+            maturity_,
+            timeScale_,
+            timestamp_,
+            balancesRatio_
+        )
+    {
+        // Suppress warning
+        this;
+    }
+
+    function testGetValue() public returns (int256) {
+        return this.getValue();
+    }
+}
+
 contract YieldValueProviderTest is DSTest, Convert {
-    Hevm internal hevm = Hevm(DSTest.HEVM_ADDRESS);
+    CheatCodes internal cheatCodes = CheatCodes(HEVM_ADDRESS);
 
     MockProvider internal mockValueProvider;
 
     YieldValueProvider internal yieldVP;
 
     // Values taken from contract
-    // https://etherscan.io/token/0x3771c99c087a81df4633b50d8b149afaa83e3c9e
-    // at block 13911954
+    // https://etherscan.io/address/0xEf82611C6120185D3BF6e020D1993B49471E7da0
+    // at block 14834025 and block 14841073
     uint256 private _maturity = 1648177200;
     int256 private _timeScale = 3168808781; // computed from 58454204609 which is in 64.64 format
-    uint112 private _cumulativeBalancesRatio =
-        5141501570599198210548627855691773;
-    uint32 private _blockTime = 1639432842;
+    uint256 private _cumulativeBalancesRatio =
+        17436777487921011541386713127552896;
+    uint32 private _blockTime = 1653460663;
+
+    uint256 private _startBlockTimestamp = 1653370980;
+    uint256 private _startCumulativeBalanceRatio =
+        17330732019965844784580556706346119;
 
     // Default oracle parameters
     uint256 private _timeUpdateWindow = 100; // seconds
@@ -40,7 +74,9 @@ contract YieldValueProviderTest is DSTest, Convert {
             // Yield arguments
             address(mockValueProvider),
             uint256(_maturity),
-            int256(_timeScale)
+            int256(_timeScale),
+            _startBlockTimestamp,
+            _startCumulativeBalanceRatio
         );
     }
 
@@ -95,35 +131,57 @@ contract YieldValueProviderTest is DSTest, Convert {
     function test_check_cumulativeBalanceRatioLast() public {
         assertEq(
             yieldVP.cumulativeBalanceRatioLast(),
-            uconvert(_cumulativeBalancesRatio, 27, 18),
+            uconvert(_startCumulativeBalanceRatio, 27, 18),
             "Invalid cumulativeBalanceRatioLast"
         );
     }
 
-    function test_check_blockTimestampLast() public {
+    function test_check_balanceTimestampLast() public {
         assertEq(
-            yieldVP.blockTimestampLast(),
-            _blockTime,
-            "Invalid blockTimestampLast"
+            yieldVP.balanceTimestampLast(),
+            _startBlockTimestamp,
+            "Invalid balanceTimestampLast"
         );
+    }
+
+    function test_getValue_failsWhenCalledByOthers() public {
+        cheatCodes.expectRevert(
+            abi.encodeWithSelector(
+                YieldValueProvider
+                    .YieldProtocolValueProvider__getValue_onlyOracleCanCall
+                    .selector
+            )
+        );
+        yieldVP.getValue();
     }
 
     function test_getValue() public {
-        // Values take from contract
-        // https://etherscan.io/token/0x3771c99c087a81df4633b50d8b149afaa83e3c9e
-        // at block 13800244
-        int256 expectedValue = 1204540138;
+        // In order to test the getValue method we will wrap the yield value provider contract
+        // inside another helper contract witch exposes the getValue method
+        YieldValueProviderHelper yieldHelper = new YieldValueProviderHelper(
+            // Oracle arguments
+            // Time update window
+            _timeUpdateWindow,
+            // Yield arguments
+            address(mockValueProvider),
+            uint256(_maturity),
+            int256(_timeScale),
+            _startBlockTimestamp,
+            _startCumulativeBalanceRatio
+        );
+
+        int256 expectedValue = 531050252;
         setMockValues(
             mockValueProvider,
-            7342183639948751441026554744281105,
-            1640937617
+            17436777487921011541386713127552896,
+            1653460663
         );
-        int256 value = yieldVP.getValue();
-        assertTrue(value == expectedValue);
+
+        assertTrue(yieldHelper.testGetValue() == expectedValue);
     }
 
     function testFail_getValue_revertsOnOrAfterMaturityDate() public {
-        hevm.warp(yieldVP.maturity());
+        cheatCodes.warp(yieldVP.maturity());
         yieldVP.getValue();
     }
 }


### PR DESCRIPTION
### Description

Update the Yield Oracle in two ways:
1. The oracle receives a cumulative balance timestamp and ratio when deployed instead of interrogating the pool in the constructor. This is done because we want to avoid having to wait for a new transaction to happen in the pool before we can update the rate. By controlling the start time for the oracle we can assure that the update flow will be successful. 
2. The ``getValue()`` function will revert if it's called from outside the oracle contract. We did this to prevent malicious actors from blocking oracle updates by front-running the keeper.

### Todo

- [x] Link issues
- [x] Link projects
- [x] Update tests
- [x] Update code
- [x] Comment code
- [x] Test locally
- [x] Update changelog